### PR TITLE
Fixing total relation size for pg12

### DIFF
--- a/pg_diff/pg_diff.py
+++ b/pg_diff/pg_diff.py
@@ -486,7 +486,7 @@ class DBTableTotalSizeDiff(DBDiffBase):
     select
       table_schema,
       table_name,
-      pg_total_relation_size(table_name)
+      pg_total_relation_size(quote_ident(table_name))
     from information_schema.tables
     where
       table_schema not in {}


### PR DESCRIPTION
Due to column type changes between PSQL 9 and 12, the pg_total_relation_size operation needs to be modified to work.